### PR TITLE
updated css for sidebar to match height of body when over 1 screen

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Sidebar = ({ titles, loadDocs }) => {
   return (
-    <div className="flex flex-col min-w-[500px] w-[500px] h-full bg-slate-900 p-10 pt-16">
+    <div className="flex flex-col min-w-[500px] w-[500px] min-h-screen bg-slate-900 p-10 pt-16">
       <h2 className="pb-4 text-slate-400 font-bold text-xl">My Documents</h2>
       {titles ? (
         titles.map((document, index) => (

--- a/src/pages/Markdown.jsx
+++ b/src/pages/Markdown.jsx
@@ -242,7 +242,7 @@ const MarkDown = () => {
     );
   } else {
     return (
-      <div className="flex flex-row h-[20000px]">
+      <div className="flex flex-row">
         {showSaveModal ? <SaveModal saveFunction={newDocument} /> : <></>}
         {showSidebar ? (
           <Sidebar titles={savedDocTitles} loadDocs={loadDoc} />


### PR DESCRIPTION
Updated the CSS for the sidebar. It was fixed to screen height. It is now clamped at min screen height, so it will grow when the body of the document grows.